### PR TITLE
Added the exception data dictionary to the error description for pips.

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
-    "name": "pip-services3-commons",
-    "registry": "pipdevs",
-    "version": "3.0.15",
-    "build": "0"
+    "name":  "pip-services3-commons",
+    "registry":  "pipdevs",
+    "version":  "3.0.16",
+    "build":  "0"
 }

--- a/src/Errors/ErrorDescriptionFactory.cs
+++ b/src/Errors/ErrorDescriptionFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using PipServices3.Commons.Data;
 
 namespace PipServices3.Commons.Errors
 {
@@ -50,6 +51,7 @@ namespace PipServices3.Commons.Errors
                 Status = 500,
                 Code = "UNKNOWN",
                 Message = ex.Message,
+                Details = new StringValueMap(ex.Data),
                 StackTrace = ex.StackTrace,
                 CorrelationId = correlationId,
                 Cause = ex.InnerException != null ? ComposeCause(ex.InnerException) : null

--- a/src/Validate/OnlyOneExistsRule.cs
+++ b/src/Validate/OnlyOneExistsRule.cs
@@ -55,7 +55,7 @@ namespace PipServices3.Commons.Validate
                         path,
                         ValidationResultType.Error,
                         "VALUE_NULL",
-                        name + " must hae at least one property from " + _properties,
+                        name + " must have at least one property from " + _properties,
                         _properties,
                         null
                     )

--- a/src/src.csproj
+++ b/src/src.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -6,7 +6,7 @@
     <RootNamespace>PipServices3.Commons</RootNamespace>
     <ApplicationIcon />
     <Win32Resource />
-    <Version>3.0.15</Version>
+    <Version>3.0.16</Version>
     <Authors>Sergey Seroukhov, Volodymyr Tkachenko, Alex Mazur, Alexey Dvoykin</Authors>
     <Copyright>Conceptual Vision Consulting LLC. 2017-2019</Copyright>
     <Description>Portable abstractions and patterns for Pip.Services in .NET</Description>

--- a/test/Errors/ErrorDescriptionFactoryTest.cs
+++ b/test/Errors/ErrorDescriptionFactoryTest.cs
@@ -52,6 +52,7 @@ namespace PipServices3.Commons.Test.Errors
             Assert.Null(descr.CorrelationId);
 
             ex = new Exception("message");
+            ex.Data.Add("key", "value");
             const string correlation = "correlation1234";
             var withCorrelation = ErrorDescriptionFactory.Create(ex, correlation);
 
@@ -62,6 +63,7 @@ namespace PipServices3.Commons.Test.Errors
             Assert.Equal(500, withCorrelation.Status);
             Assert.Equal(ex.StackTrace, withCorrelation.StackTrace);
             Assert.Equal(correlation, withCorrelation.CorrelationId);
+            Assert.Equal(ex.Data, withCorrelation.Details);
         }
     }
 }


### PR DESCRIPTION
The error create method has been updated to process the Data dictionary that can be present with an exception. This dictionary allows users to log more information about the exception and ensure that it's carried through and logged.

**Commit Message**
This allows user to log custom data for an exception.
Unit test updated for the change.

Version rev'd